### PR TITLE
Encoding in ruby 1.9 and umlaouts

### DIFF
--- a/lib/game.rb
+++ b/lib/game.rb
@@ -1,3 +1,5 @@
+#encoding: UTF-8
+
 require 'rubygems'
 require 'amatch'
 require 'colorize'


### PR DESCRIPTION
Hei, I'm trying to create a small sinatra app as a front end for your application. I'd like to see if i can use the core of your gem to implement the use case I described you on Saturday. So I gem installed everything but I had the following error popping up when i was requiring the gem:

/home/alphy/.rvm/gems/ruby-1.9.3-p194@german-learning-sinatra/gems/text-analysis-utils-0.3/lib/game.rb:29: syntax error, unexpected $end, expecting ')'  
        w.gsub("ä", "ae").gsub("ö", "oe").gsub("ü", "ue").gsub("ß", "ss")
                               ^

I looked around and it seems that 1.9 is a lot more restrictive about the character encoding:

http://zargony.com/2009/07/24/ruby-1-9-and-file-encodings

Given your file is in UTF-8 (file --mime) I added the header and it now works fine
